### PR TITLE
Net http error quoting

### DIFF
--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -388,7 +388,7 @@ func TestHTTPClientGetReturnsErrorOnClientCallFailure(t *testing.T) {
 
 	require.Nil(t, response)
 
-	assert.Equal(t, "Get : unsupported protocol scheme \"\"", err.Error())
+	assert.Equal(t, `Get "": unsupported protocol scheme ""`, err.Error())
 }
 
 func TestHTTPClientGetReturnsNoErrorOn5xxFailure(t *testing.T) {
@@ -412,7 +412,7 @@ func TestHTTPClientGetReturnsErrorOnFailure(t *testing.T) {
 	client := NewClient(WithHTTPTimeout(10 * time.Millisecond))
 
 	response, err := client.Get("url_doesnt_exist", http.Header{})
-	require.EqualError(t, err, "Get url_doesnt_exist: unsupported protocol scheme \"\"")
+	require.EqualError(t, err, `Get "url_doesnt_exist": unsupported protocol scheme ""`)
 	require.Nil(t, response)
 
 }

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -411,8 +411,8 @@ func TestHTTPClientGetReturnsNoErrorOn5xxFailure(t *testing.T) {
 func TestHTTPClientGetReturnsErrorOnFailure(t *testing.T) {
 	client := NewClient(WithHTTPTimeout(10 * time.Millisecond))
 
-	response, err := client.Get("url_doenst_exist", http.Header{})
-	require.EqualError(t, err, "Get url_doenst_exist: unsupported protocol scheme \"\"")
+	response, err := client.Get("url_doesnt_exist", http.Header{})
+	require.EqualError(t, err, "Get url_doesnt_exist: unsupported protocol scheme \"\"")
 	require.Nil(t, response)
 
 }

--- a/hystrix/hystrix_client_test.go
+++ b/hystrix/hystrix_client_test.go
@@ -275,7 +275,7 @@ func TestHystrixHTTPClientRetriesGetOnFailure(t *testing.T) {
 	)
 
 	response, err := client.Get("url_doesnt_exist", http.Header{})
-	require.EqualError(t, err, `Get url_doesnt_exist: unsupported protocol scheme ""`)
+	require.EqualError(t, err, `Get "url_doesnt_exist": unsupported protocol scheme ""`)
 
 	assert.Nil(t, response)
 }


### PR DESCRIPTION
fix fail unit test caused by changes in go net/url error message
[original PR](https://github.com/golang/go/pull/29384/files#diff-6c2d018290e298803c0c9419d8739885R29) in go

fix typo in the unit test