### PR TITLE
fix issue #79: add /v6 module import suffix

### DIFF
--- a/examples/client.go
+++ b/examples/client.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gojektech/heimdall"
-	"github.com/gojektech/heimdall/httpclient"
-	"github.com/gojektech/heimdall/hystrix"
+	"github.com/gojektech/heimdall/v6"
+	"github.com/gojektech/heimdall/v6/httpclient"
+	"github.com/gojektech/heimdall/v6/hystrix"
 	"github.com/pkg/errors"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,6 @@
-module github.com/gojektech/heimdall
+module github.com/gojektech/heimdall/v6
+
+go 1.11
 
 require (
 	github.com/afex/hystrix-go v0.0.0-20180209013831-27fae8d30f1a

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gojektech/heimdall"
+	"github.com/gojektech/heimdall/v6"
 	"github.com/gojektech/valkyrie"
 	"github.com/pkg/errors"
 )

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gojektech/heimdall"
+	"github.com/gojektech/heimdall/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/httpclient/options.go
+++ b/httpclient/options.go
@@ -3,7 +3,7 @@ package httpclient
 import (
 	"time"
 
-	"github.com/gojektech/heimdall"
+	"github.com/gojektech/heimdall/v6"
 )
 
 // Option represents the client options

--- a/httpclient/options_test.go
+++ b/httpclient/options_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gojektech/heimdall"
+	"github.com/gojektech/heimdall/v6"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/hystrix/hystrix_client.go
+++ b/hystrix/hystrix_client.go
@@ -2,14 +2,14 @@ package hystrix
 
 import (
 	"bytes"
-	"github.com/gojektech/heimdall/httpclient"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
 
 	"github.com/afex/hystrix-go/hystrix"
-	"github.com/gojektech/heimdall"
+	"github.com/gojektech/heimdall/v6"
+	"github.com/gojektech/heimdall/v6/httpclient"
 	"github.com/pkg/errors"
 )
 

--- a/hystrix/hystrix_client_test.go
+++ b/hystrix/hystrix_client_test.go
@@ -5,12 +5,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
-	"strings"
-
-	"github.com/gojektech/heimdall"
+	"github.com/gojektech/heimdall/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/hystrix/options.go
+++ b/hystrix/options.go
@@ -1,10 +1,10 @@
 package hystrix
 
 import (
-	"github.com/gojektech/heimdall/httpclient"
 	"time"
 
-	"github.com/gojektech/heimdall"
+	"github.com/gojektech/heimdall/v6"
+	"github.com/gojektech/heimdall/v6/httpclient"
 )
 
 // Option represents the hystrix client options

--- a/plugins/request_logger.go
+++ b/plugins/request_logger.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/gojektech/heimdall"
+	"github.com/gojektech/heimdall/v6"
 )
 
 type ctxKey string


### PR DESCRIPTION
@sohamkamani I've added `/v6` import suffix to resolve issue #79 introduced with `v5.1.0` release with https://github.com/gojek/heimdall/pull/40.

According to https://github.com/golang/go/wiki/Modules#why-must-major-version-numbers-appear-in-import-paths the major version must present in import paths.

If you wish, I could do it in v5 module, to fix the buggy `v5.1.0` version, but it's strongly recommended to increase major version after adopting go modules: https://github.com/golang/go/wiki/Modules#incrementing-the-major-version-when-first-adopting-modules-with-v2-packages, so I've made it `v6`. 

And please have a look at https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher
In short, there could be some problems with `godep` users with major go.mod in master. So we could introduce better compatibility with `v6` subdirectory for non-gomod users.
But if you dropped Gopkg.toml support, maybe it's unnecessary. 

Let's discuss an fix it ASAP to have better go.mod support 🙇 