### PR TITLE
Fix backoff strategies

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -31,9 +31,6 @@ func NewConstantBackoff(backoffInterval, maximumJitterInterval time.Duration) Ba
 
 // Next returns next time for retrying operation with constant strategy
 func (cb *constantBackoff) Next(retry int) time.Duration {
-	if retry <= 0 {
-		return 0 * time.Millisecond
-	}
 	return (time.Duration(cb.backoffInterval) * time.Millisecond) + (time.Duration(rand.Int63n(cb.maximumJitterInterval)) * time.Millisecond)
 }
 
@@ -57,8 +54,5 @@ func NewExponentialBackoff(initialTimeout, maxTimeout time.Duration, exponentFac
 
 // Next returns next time for retrying operation with exponential strategy
 func (eb *exponentialBackoff) Next(retry int) time.Duration {
-	if retry <= 0 {
-		return 0 * time.Millisecond
-	}
-	return time.Duration(math.Min(eb.initialTimeout+math.Pow(eb.exponentFactor, float64(retry)), eb.maxTimeout)+float64(rand.Int63n(eb.maximumJitterInterval))) * time.Millisecond
+	return time.Duration(math.Min(eb.initialTimeout*math.Pow(eb.exponentFactor, float64(retry)), eb.maxTimeout)+float64(rand.Int63n(eb.maximumJitterInterval))) * time.Millisecond
 }

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -8,43 +8,85 @@ import (
 )
 
 func TestExponentialBackoffNextTime(t *testing.T) {
-	exponentialBackoff := NewExponentialBackoff(2*time.Millisecond, 10*time.Millisecond, 2.0, 1*time.Millisecond)
+	exponentialBackoff := NewExponentialBackoff(100*time.Millisecond, 1000*time.Millisecond, 2.0, 0*time.Millisecond)
 
-	assert.True(t, 4*time.Millisecond <= exponentialBackoff.Next(1))
+	assert.Equal(t, 100*time.Millisecond, exponentialBackoff.Next(0))
+	assert.Equal(t, 200*time.Millisecond, exponentialBackoff.Next(1))
+	assert.Equal(t, 400*time.Millisecond, exponentialBackoff.Next(2))
+	assert.Equal(t, 800*time.Millisecond, exponentialBackoff.Next(3))
 }
 
 func TestExponentialBackoffMaxTimeoutCrossed(t *testing.T) {
-	exponentialBackoff := NewExponentialBackoff(2*time.Millisecond, 9*time.Millisecond, 2.0, 1*time.Millisecond)
+	exponentialBackoff := NewExponentialBackoff(100*time.Millisecond, 1000*time.Millisecond, 2.0, 0*time.Millisecond)
 
-	assert.True(t, 9*time.Millisecond <= exponentialBackoff.Next(3))
+	assert.Equal(t, 1000*time.Millisecond, exponentialBackoff.Next(4))
 }
 
 func TestExponentialBackoffMaxTimeoutReached(t *testing.T) {
-	exponentialBackoff := NewExponentialBackoff(2*time.Millisecond, 10*time.Millisecond, 2.0, 1*time.Millisecond)
+	exponentialBackoff := NewExponentialBackoff(100*time.Millisecond, 1600*time.Millisecond, 2.0, 0*time.Millisecond)
 
-	assert.True(t, 10*time.Millisecond <= exponentialBackoff.Next(3))
+	assert.Equal(t, 1600*time.Millisecond, exponentialBackoff.Next(4))
 }
 
-func TestExponentialBackoffWhenRetryIsZero(t *testing.T) {
-	exponentialBackoff := NewExponentialBackoff(2*time.Millisecond, 10*time.Millisecond, 2.0, 1*time.Millisecond)
+func TestExponentialBackoffWhenRetryIsLessThanZero(t *testing.T) {
+	exponentialBackoff := NewExponentialBackoff(100*time.Millisecond, 1000*time.Millisecond, 2.0, 0*time.Millisecond)
 
-	assert.True(t, 0*time.Millisecond <= exponentialBackoff.Next(0))
+	assert.Equal(t, 100*time.Millisecond, exponentialBackoff.Next(-1))
 }
 
-func TestExponentialBackoffJitter(t *testing.T) {
-	exponentialBackoff := NewExponentialBackoff(2*time.Millisecond, 10*time.Millisecond, 2.0, 2*time.Millisecond)
+func TestExponentialBackoffJitter0(t *testing.T) {
+	exponentialBackoff := NewExponentialBackoff(100*time.Millisecond, 1000*time.Millisecond, 2.0, 0*time.Millisecond)
+	for i := 0; i < 10000; i++ {
+		assert.Equal(t, 200*time.Millisecond, exponentialBackoff.Next(1))
+	}
+}
 
-	assert.True(t, 4*time.Millisecond <= exponentialBackoff.Next(1))
+func TestExponentialBackoffJitter1(t *testing.T) {
+	exponentialBackoff := NewExponentialBackoff(100*time.Millisecond, 1000*time.Millisecond, 2.0, 1*time.Millisecond)
+	for i := 0; i < 10000; i++ {
+		assert.True(t, 200*time.Millisecond <= exponentialBackoff.Next(1) && exponentialBackoff.Next(1) <= 201*time.Millisecond)
+	}
+}
+
+func TestExponentialBackoffJitter50(t *testing.T) {
+	exponentialBackoff := NewExponentialBackoff(100*time.Millisecond, 1000*time.Millisecond, 2.0, 50*time.Millisecond)
+	for i := 0; i < 10000; i++ {
+		assert.True(t, 200*time.Millisecond <= exponentialBackoff.Next(1) && exponentialBackoff.Next(1) <= 250*time.Millisecond)
+	}
 }
 
 func TestConstantBackoffNextTime(t *testing.T) {
-	constantBackoff := NewConstantBackoff(100*time.Millisecond, 50*time.Millisecond)
+	constantBackoff := NewConstantBackoff(100*time.Millisecond, 0*time.Millisecond)
 
-	assert.True(t, 100*time.Millisecond <= constantBackoff.Next(1))
+	assert.Equal(t, 100*time.Millisecond, constantBackoff.Next(0))
+	assert.Equal(t, 100*time.Millisecond, constantBackoff.Next(1))
+	assert.Equal(t, 100*time.Millisecond, constantBackoff.Next(2))
+	assert.Equal(t, 100*time.Millisecond, constantBackoff.Next(3))
 }
 
-func TestConstantBackoffWhenRetryIsZero(t *testing.T) {
-	constantBackoff := NewConstantBackoff(100*time.Millisecond, 50*time.Millisecond)
+func TestConstantBackoffWhenRetryIsLessThanZero(t *testing.T) {
+	constantBackoff := NewConstantBackoff(100*time.Millisecond, 0*time.Millisecond)
 
-	assert.True(t, 0*time.Millisecond <= constantBackoff.Next(0))
+	assert.Equal(t, 100*time.Millisecond, constantBackoff.Next(-1))
+}
+
+func TestConstantBackoffJitter0(t *testing.T) {
+	constantBackoff := NewConstantBackoff(100*time.Millisecond, 0*time.Millisecond)
+	for i := 0; i < 10000; i++ {
+		assert.Equal(t, 100*time.Millisecond, constantBackoff.Next(i))
+	}
+}
+
+func TestConstantBackoffJitter1(t *testing.T) {
+	constantBackoff := NewConstantBackoff(100*time.Millisecond, 1*time.Millisecond)
+	for i := 0; i < 10000; i++ {
+		assert.True(t, 100*time.Millisecond <= constantBackoff.Next(i) && constantBackoff.Next(1) <= 101*time.Millisecond)
+	}
+}
+
+func TestConstantBackoffJitter50(t *testing.T) {
+	constantBackoff := NewConstantBackoff(100*time.Millisecond, 50*time.Millisecond)
+	for i := 0; i < 10000; i++ {
+		assert.True(t, 100*time.Millisecond <= constantBackoff.Next(i) && constantBackoff.Next(1) <= 150*time.Millisecond)
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/gojek/heimdall/issues/82 and Resolves https://github.com/gojek/heimdall/issues/83

Tested by checking timestamps in request logs when requesting from a test server that just returns 500.

```go
func main() {
	fmt.Println("testing constant backoff ...")
	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
		w.WriteHeader(500)
	}))
	defer s.Close()
	cli := httpclient.NewClient(
		httpclient.WithRetryCount(3),
		httpclient.WithHTTPClient(s.Client()),
		httpclient.WithRetrier(
			heimdall.NewRetrier(
				heimdall.NewConstantBackoff(
					2*time.Second,
					2*time.Millisecond,
				),
			),
		),
	)
	cli.AddPlugin(plugins.NewRequestLogger(os.Stdout, os.Stderr))
	_, _ = cli.Get(s.URL, nil)

	fmt.Println("testing exponential backoff...")
	cli = httpclient.NewClient(
		httpclient.WithRetryCount(5),
		httpclient.WithHTTPClient(s.Client()),
		httpclient.WithRetrier(
			heimdall.NewRetrier(
				heimdall.NewExponentialBackoff(
					1*time.Second,
					8*time.Second,
					2,
					2*time.Millisecond,
				),
			),
		),
	)
	cli.AddPlugin(plugins.NewRequestLogger(os.Stdout, os.Stderr))
	_, _ = cli.Get(s.URL, nil)
}
```

For constant backoff, expect to see 2 seconds between requests.

For exponential backoff, with min=1 second, max=8 second, exp. factor=2, should see backoffs of 1, 2, 4, 8, 8.

Logs confirm expected behavior:

```
go run main.go
testing constant backoff ...
21/May/2020 11:08:21 GET http://127.0.0.1:51320 500 [0ms]
21/May/2020 11:08:23 GET http://127.0.0.1:51320 500 [1ms]
21/May/2020 11:08:25 GET http://127.0.0.1:51320 500 [1ms]
21/May/2020 11:08:27 GET http://127.0.0.1:51320 500 [1ms]
testing exponential backoff...
21/May/2020 11:08:29 GET http://127.0.0.1:51320 500 [1ms]
21/May/2020 11:08:30 GET http://127.0.0.1:51320 500 [0ms]
21/May/2020 11:08:32 GET http://127.0.0.1:51320 500 [0ms]
21/May/2020 11:08:36 GET http://127.0.0.1:51320 500 [0ms]
21/May/2020 11:08:44 GET http://127.0.0.1:51320 500 [0ms]
21/May/2020 11:08:52 GET http://127.0.0.1:51320 500 [0ms]
```