### PR TITLE
Handle request cancellation properly

### DIFF
--- a/hystrix/hystrix_client.go
+++ b/hystrix/hystrix_client.go
@@ -205,6 +205,14 @@ func (hhc *Client) Do(request *http.Request) (*http.Response, error) {
 		}, hhc.fallbackFunc)
 
 		if err != nil {
+			// If the request context has already been cancelled, don't retry
+			ctx := request.Context()
+			select {
+			case <-ctx.Done():
+				return nil, err
+			default:
+			}
+
 			backoffTime := hhc.retrier.NextInterval(i)
 			time.Sleep(backoffTime)
 			continue

--- a/hystrix/hystrix_client_test.go
+++ b/hystrix/hystrix_client_test.go
@@ -2,6 +2,7 @@ package hystrix
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -341,6 +342,48 @@ func BenchmarkHystrixHTTPClientRetriesGetOnFailure(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, _ = client.Get(server.URL, http.Header{})
 	}
+}
+
+func TestHystrixHTTPClientDontRetryWhenContextIsCancelled(t *testing.T) {
+	count := 0
+	noOfRetries := 3
+	// Set a huge backoffInterval that we won't have to wait anyway
+	backoffInterval := 1 * time.Hour
+	maximumJitterInterval := 1 * time.Millisecond
+
+	client := NewClient(
+		WithHTTPTimeout(10*time.Millisecond),
+		WithCommandName("some_command_name"),
+		WithHystrixTimeout(10*time.Millisecond),
+		WithMaxConcurrentRequests(100),
+		WithErrorPercentThreshold(10),
+		WithSleepWindow(100),
+		WithRequestVolumeThreshold(10),
+		WithRetryCount(noOfRetries),
+		WithRetrier(heimdall.NewRetrier(heimdall.NewConstantBackoff(backoffInterval, maximumJitterInterval))),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{ "response": "something went wrong" }`))
+		count++
+		// Cancel the context after the first call
+		cancel()
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(dummyHandler))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	response, err := client.Do(req.WithContext(ctx))
+	require.Error(t, err, "should have failed to make request")
+	require.Nil(t, response)
+
+	assert.Equal(t, 1, count)
 }
 
 func TestHystrixHTTPClientRetriesPostOnFailure(t *testing.T) {


### PR DESCRIPTION
When a request is being cancelled by the caller via the context, even though the underlying HTTP client should not perform any more request and directly return, the backoff mechanism still kicks in and leaves the caller waiting for multiple backoff periods for nothing.

I had a look at #17 and #28 and thought that maybe this solution, that does not change the signatures and fully uses the context that callers set on the HTTP request might work.

I have implemented a very basic test for both clients but still have an issue with the hystrix client. I wanted to submit this draft before investing more time and see if this patch would be relevant.