### PR TITLE
Update Go documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ For a simple example on how to write plugins, look at the [request logger plugin
 
 ## Documentation
 
-Further documentation can be found on [godoc.org](https://www.godoc.org/github.com/gojektech/heimdall)
+Further documentation can be found on [pkg.go.dev](https://pkg.go.dev/github.com/gojektech/heimdall)
 
 ## FAQ
 


### PR DESCRIPTION
[pkg.go.dev](https://pkg.go.dev ) is the new home for documentation of Go projects as referenced in the Go [blog post](https://blog.golang.org/pkgsite-redesign)