### PR TITLE
Fixing ambiguous import on statsd client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/DataDog/datadog-go v3.7.1+incompatible // indirect
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
-	github.com/cactus/go-statsd-client v3.0.1+incompatible // indirect
+	github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c // indirect
 	github.com/gojek/valkyrie v0.0.0-20180215180059-6aee720afcdf
 	github.com/pkg/errors v0.9.1
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/DataDog/datadog-go v3.7.1+incompatible h1:HmA9qHVrHIAqpSvoCYJ+c6qst0l
 github.com/DataDog/datadog-go v3.7.1+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5 h1:rFw4nCn9iMW+Vajsk51NtYIcwSTkXr+JGrMd36kTDJw=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
-github.com/cactus/go-statsd-client v3.0.1+incompatible h1:Fk6etBCheGhbrRmfHuaetxZ6H9/Mp2xl4D+Dcxo19zo=
-github.com/cactus/go-statsd-client v3.0.1+incompatible/go.mod h1:cMRcwZDklk7hXp+Law83urTHUiHMzCev/r4JMYr/zU0=
+github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c h1:HIGF0r/56+7fuIZw2V4isE22MK6xpxWx7BbV8dJ290w=
+github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
- adjust indirect dependency `statsd` used in `afex/hystrix-go` to `v0.0.0-20200423205355-cb0885a1018c`

Possible issue that produced by the v7.0.1
```
        github.com/gojek/heimdall/v7/hystrix imports
        github.com/afex/hystrix-go/plugins imports
        github.com/cactus/go-statsd-client/statsd: ambiguous import: found package github.com/cactus/go-statsd-client/statsd in multiple modules:
        github.com/cactus/go-statsd-client v3.0.1+incompatible (/Users/danny/go/pkg/mod/github.com/cactus/go-statsd-client@v3.0.1+incompatible/statsd)
        github.com/cactus/go-statsd-client/statsd v0.0.0-20200728222731-a2baea3bbfc6 (/Users/danny/go/pkg/mod/github.com/cactus/go-statsd-client/statsd@v0.0.0-20200728222731-a2baea3bbfc6)
```
