### PR TITLE
The target all includes setup to install golint, goveralls before executing build and coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.PHONYthub.com/mattn/goveralls: all
-all: build test coverage
+.PHONY: all
+all: setup build test coverage
 
 ALL_PACKAGES=$(shell go list ./... | grep -v "vendor")
 


### PR DESCRIPTION
**Expected**: The command `make` executes successfully.

**Actual**: The command `make` fails with `/bin/sh: 1: goveralls: not found`

![make-doesnt-download-goveralls](https://user-images.githubusercontent.com/26689027/148671369-ac6d11b3-517a-45ee-b9c8-30131b944ff1.png)

**Potential reason**: The Makefile has the `.PHONY` target: `all` that may execute the targets: `build`, `test`, `coverage`. However, the command `make` fails as the prerequisites are not downloaded before executing the targets.

**What changes were made in the PR**:
1. Removed unnecessary strings attached with the `.PHONY` target.
2. Added the target `setup` in the `all` target so that `golint` and `goveralls` are installed before executing the `build` and `coverage` targets. 