### PR TITLE
fix bug & some optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ A plugin is an interface whose methods get called during key events in a request
 
 - `OnRequestStart` is called just before the request is made
 - `OnRequestEnd` is called once the request has successfully executed
-- `OnError` is called is the request failed
+- `OnError` is called when the request failed
 
 Each method is called with the request object as an argument, with `OnRequestEnd`, and `OnError` additionally being called with the response and error instances respectively.
 For a simple example on how to write plugins, look at the [request logger plugin](/plugins/request_logger.go).

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/DataDog/datadog-go v3.7.1+incompatible // indirect
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c // indirect
-	github.com/gojek/valkyrie v0.0.0-20180215180059-6aee720afcdf
 	github.com/pkg/errors v0.9.1
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,12 +4,9 @@ github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5 h1:rFw4nCn9iMW+Vaj
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c h1:HIGF0r/56+7fuIZw2V4isE22MK6xpxWx7BbV8dJ290w=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gojek/valkyrie v0.0.0-20180215180059-6aee720afcdf h1:5xRGbUdOmZKoDXkGx5evVLehuCMpuO1hl701bEQqXOM=
-github.com/gojek/valkyrie v0.0.0-20180215180059-6aee720afcdf/go.mod h1:QzhUKaYKJmcbTnCYCAVQrroCOY7vOOI8cSQ4NbuhYf0=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -137,7 +137,7 @@ func (c *Client) Do(request *http.Request) (*http.Response, error) {
 	}
 
 	var err error
-	var shouldRetry bool
+	var needRetry bool
 	var response *http.Response
 
 	for i := 0; ; i++ {
@@ -154,7 +154,7 @@ func (c *Client) Do(request *http.Request) (*http.Response, error) {
 			_, _ = bodyReader.Seek(0, 0)
 		}
 
-		shouldRetry, err = c.checkRetry(request.Context(), response, err)
+		needRetry, err = c.checkRetry(request.Context(), response, err)
 
 		if err != nil {
 			c.reportError(request, err)
@@ -162,7 +162,7 @@ func (c *Client) Do(request *http.Request) (*http.Response, error) {
 			c.reportRequestEnd(request, response)
 		}
 
-		if !shouldRetry {
+		if !needRetry {
 			break
 		}
 

--- a/httpclient/options_test.go
+++ b/httpclient/options_test.go
@@ -128,6 +128,5 @@ func ExampleWithRetrier() {
 	// Output: retry attempt 0
 	// retry attempt 1
 	// retry attempt 2
-	// retry attempt 3
 	// error
 }


### PR DESCRIPTION
1. add unit tests TestHTTPClientGetRetriesOnTimeout
2. fix issue #89/#94: retrier called even with 0 retry count and time sleep will be called even when the retries are exhausted
3. Cancel the retry sleep if the request context is canceled or the deadline exceeded

some proposal:
1. an interface or option through which we can customize the retry policy (check error check resp.StatusCode)
2. some times, we need to know the number of retries and responses when the retrier called. Is any idea about this?
	I implemented a version using the existing method, but it was not very good [get the retry times](https://github.com/Panlq/heimdall/commit/376122286bdc375558987f84da3a94b14359e166)


```golang
type Plugin interface {
	OnRequestStart(*http.Request)
	OnRequestEnd(*http.Request, *http.Response)
	// the response struct contains the request. add a attempt num when the err handler?
	OnError(*http.Response, error, int)   
}
```
