### PR TITLE
docs(hystrix): document config option units and meanings (#143)

### DIFF
--- a/hystrix/options.go
+++ b/hystrix/options.go
@@ -35,28 +35,33 @@ func WithHystrixTimeout(timeout time.Duration) Option {
 	}
 }
 
-// WithMaxConcurrentRequests sets hystrix max concurrent requests
+// WithMaxConcurrentRequests sets the maximum number of concurrent requests
+// allowed to the command before further requests are short-circuited.
 func WithMaxConcurrentRequests(maxConcurrentRequests int) Option {
 	return func(c *Client) {
 		c.maxConcurrentRequests = maxConcurrentRequests
 	}
 }
 
-// WithRequestVolumeThreshold sets hystrix request volume threshold
+// WithRequestVolumeThreshold sets the minimum number of requests in a rolling
+// window needed before the circuit breaker can trip.
 func WithRequestVolumeThreshold(requestVolumeThreshold int) Option {
 	return func(c *Client) {
 		c.requestVolumeThreshold = requestVolumeThreshold
 	}
 }
 
-// WithSleepWindow sets hystrix sleep window
+// WithSleepWindow sets how long, in milliseconds, to wait after the circuit
+// opens before allowing a single retry to test whether the backend has recovered.
+// The value is passed through to hystrix unchanged (hystrix defaults to 5000ms).
 func WithSleepWindow(sleepWindow int) Option {
 	return func(c *Client) {
 		c.sleepWindow = sleepWindow
 	}
 }
 
-// WithErrorPercentThreshold sets hystrix error percent threshold
+// WithErrorPercentThreshold sets the error percentage (0-100) at or above which,
+// once the request volume threshold is met, the circuit breaker opens.
 func WithErrorPercentThreshold(errorPercentThreshold int) Option {
 	return func(c *Client) {
 		c.errorPercentThreshold = errorPercentThreshold


### PR DESCRIPTION
### Addresses #143

The hystrix `Client` options (`WithSleepWindow`, `WithRequestVolumeThreshold`, `WithErrorPercentThreshold`, `WithMaxConcurrentRequests`) only had doc comments like "sets hystrix sleep window" with no unit or meaning. As reported in #143, this makes it unclear whether e.g. the sleep window is seconds or milliseconds.

These values are passed through to `afex/hystrix-go` unchanged, so this documents them to match that library's semantics — sleep window in milliseconds (hystrix default 5000ms), request volume threshold as a request count, error percent threshold as a 0-100 percentage. No behavior change.
