### PR TITLE
test: fix flaky tests

### DIFF
--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -691,6 +691,7 @@ func TestHTTPClientDoContextCancelledBeforeRetry(t *testing.T) {
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		cancel() // Cancel immediately
 		count.Add(1)
+		<-r.Context().Done() // Wait for cancelation to propagate
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 
@@ -703,7 +704,7 @@ func TestHTTPClientDoContextCancelledBeforeRetry(t *testing.T) {
 
 	_, err = client.Do(req)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), context.Canceled.Error())
+	assert.ErrorIs(t, err, context.Canceled)
 	assert.Equal(t, int32(1), count.Load())
 }
 

--- a/hystrix/hystrix_client_test.go
+++ b/hystrix/hystrix_client_test.go
@@ -342,9 +342,9 @@ func TestHystrixHTTPClientRetriesWithBudgetGetOnFailure5xx(t *testing.T) {
 	maximumJitterInterval := 1 * time.Millisecond
 
 	client := NewClient(
-		WithHTTPTimeout(10*time.Millisecond),
+		WithHTTPTimeout(100*time.Millisecond),
 		WithCommandName("some_command_name_5xx_with_budget"),
-		WithHystrixTimeout(10*time.Millisecond),
+		WithHystrixTimeout(100*time.Millisecond),
 		WithMaxConcurrentRequests(100),
 		WithErrorPercentThreshold(25),
 		WithSleepWindow(100),


### PR DESCRIPTION
Fixes these flaky tests on CI:

https://github.com/gojek/heimdall/actions/runs/27264843190/job/80519290697

```
--- FAIL: TestHystrixHTTPClientRetriesWithBudgetGetOnFailure5xx (0.15s)
    hystrix_client_test.go:380: 
        	Error Trace:	/home/runner/work/heimdall/heimdall/hystrix/hystrix_client_test.go:380
        	Error:      	Received unexpected error:
        	            	hystrix: timeout
        	Test:       	TestHystrixHTTPClientRetriesWithBudgetGetOnFailure5xx
```

https://github.com/gojek/heimdall/actions/runs/27264843190/job/82395349637

```
--- FAIL: TestHTTPClientDoContextCancelledBeforeRetry (0.00s)
    client_test.go:705: 
        	Error Trace:	/home/runner/work/heimdall/heimdall/httpclient/client_test.go:705
        	Error:      	An error is expected but got nil.
        	Test:       	TestHTTPClientDoContextCancelledBeforeRetry

```